### PR TITLE
Adding Glob Lookups for Transformed Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/bin/
 **/obj/
 **/.vscode/
+.idea

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: im-open/octostache-action@v2.0.1
+      - uses: im-open/octostache-action@v2.1.0
         with:
           variables-file: ./substitution-variables.json
           files-with-substitutions: ./src/DemoApp19/DemoApp19.csproj,./src/DemoApp19/Bff/FrontEnd/scripts/build-variables.js,./src/**/*.html

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ This is a container action so it will not work on Windows runners.
 | Parameter                  | Is Required | Description                                                                                                                                                                                                                                              |
 | -------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `variables-file`           | false       | An optional yaml file containing variables to use in the substitution.                                                                                                                                                                                   |
-| `files-with-substitutions` | true        | A comma separated list of files with `#{variables}` that need substitution.                                                                                                                                                                              |
-| `output-files`             | false       | An optional comma separated list of files to output.<br/>If defined, the program assumes the index of the output file is the same as the index of the template file in the template-files list. They therefore need to have the same number of elements. |
+| `files-with-substitutions` | true        | A comma separated list of files or [.NET-compatible glob patterns](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.filesystemglobbing.matcher?view=dotnet-plat-ext-6.0#remarks) with `#{variables}` that need substitution.                                                                                                                                                                              |
 
 ## Outputs
 
@@ -29,7 +28,7 @@ AppInsightsKey: a1b2c3
 ```
 
 ### Environment Variables
-In addition to the `variables-file` argument, substitutions can be provided in the `env:` section of the action.  The format matches what is supplied in the `variables-file`: `<var-name>: <var-value>`.  
+In addition to the `variables-file` argument, substitutions can be provided in the `env:` section of the action.  The format matches what is supplied in the `variables-file`: `<var-name>: <var-value>`.
 
 If the same item is provided in the `variables-file` and the `env:` section, the value in the `env:` section will be used.
 
@@ -59,6 +58,19 @@ const substitutionVariables = {
 };
 ```
 
+`index.html`
+```html
+<html>
+  <head>
+    <!--... head items ...-->
+    <script type="text/javascript">var gaKey = '#{GoogleAnalyticsKey}';</script>
+  </head>
+  <body>
+    <!--... application body ...-->
+  </body>
+</html>
+```
+
 ### Workflow
 
 ```yml
@@ -76,8 +88,7 @@ jobs:
       - uses: im-open/octostache-action@v2.0.1
         with:
           variables-file: ./substitution-variables.json
-          files-with-substitutions: ./src/DemoApp19/DemoApp19.csproj,./src/DemoApp19/Bff/FrontEnd/scripts/build-variables.js
-          output-files: ./src/DemoApp19/DemoApp19.csproj,./src/DemoApp19/Bff/FrontEnd/scripts/build-variables.js
+          files-with-substitutions: ./src/DemoApp19/DemoApp19.csproj,./src/DemoApp19/Bff/FrontEnd/scripts/build-variables.js,./src/**/*.html
         env:
           # Note that this value would be used over the value from the example variables file
           LaunchDarklyKey: ${{ secrets.LAUNCH_DARKLY_API_KEY }}

--- a/src/OctostacheCmd/FilesRetriever.cs
+++ b/src/OctostacheCmd/FilesRetriever.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
+
+namespace OctostacheCmd
+{
+    public static class FilesRetriever
+    {
+        public static IEnumerable<string> GetFiles(string fileGlobs)
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var globs = fileGlobs.Split(',').Select(file => file.Trim());
+            
+            var matcher = new Matcher();
+            matcher.AddIncludePatterns(globs);
+            
+            var files = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(currentDirectory)));
+            return files.Files.Select(file => file.Path);
+        }
+    }
+}

--- a/src/OctostacheCmd/OctostacheCmd.csproj
+++ b/src/OctostacheCmd/OctostacheCmd.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="octostache" Version="2.13.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />

--- a/src/OctostacheCmd/Program.cs
+++ b/src/OctostacheCmd/Program.cs
@@ -49,6 +49,13 @@ namespace OctostacheCmd
             }
 
             var templateFilesList = FilesRetriever.GetFiles(filesWithSubstitutions).ToList();
+            Console.WriteLine(
+                $"{Environment.NewLine}Files found in which make substitutions:{Environment.NewLine}");
+            foreach (var templateFile in templateFilesList)
+            {
+                Console.WriteLine(templateFile);
+            }
+
 
             var varDictionary = new VariableDictionary();
 

--- a/src/OctostacheCmd/Program.cs
+++ b/src/OctostacheCmd/Program.cs
@@ -50,7 +50,7 @@ namespace OctostacheCmd
 
             var templateFilesList = FilesRetriever.GetFiles(filesWithSubstitutions).ToList();
             Console.WriteLine(
-                $"{Environment.NewLine}Files found in which make substitutions:{Environment.NewLine}");
+                $"{Environment.NewLine}Files found in which to make substitutions:{Environment.NewLine}");
             foreach (var templateFile in templateFilesList)
             {
                 Console.WriteLine(templateFile);

--- a/src/OctostacheCmd/Program.cs
+++ b/src/OctostacheCmd/Program.cs
@@ -48,7 +48,7 @@ namespace OctostacheCmd
                 Console.WriteLine(filesWithSubstitutions);
             }
 
-            var templateFilesList = filesWithSubstitutions.Split(',').Select(file => file.Trim()).ToList();
+            var templateFilesList = FilesRetriever.GetFiles(filesWithSubstitutions).ToList();
 
             var varDictionary = new VariableDictionary();
 


### PR DESCRIPTION
This adds the option to use globs to look up files to transform. It's now described in the README this way:

> A comma separated list of files or [.NET-compatible glob patterns](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.filesystemglobbing.matcher?view=dotnet-plat-ext-6.0#remarks) with `#{variables}` that need substitution.

This is especially necessary because many of our finished javascript files have a webpack hash in their filename, and there's no consistent way to know their exact filenames per build.